### PR TITLE
chore(deps): combine dependabot updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Bump Version
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: minor
           custom_release_rules: bug:patch:Fixes,chore:patch:Chores,docs:patch:Documentation,feat:minor:Features,refactor:minor:Refactors,test:patch:Tests,ci:patch:Development,dev:patch:Development
       - name: Create Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.20.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+        uses: actions/checkout@v6
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         name: Check PR for Semantic Commit Message
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
       - name: Terraform Setup

--- a/main.tf
+++ b/main.tf
@@ -178,7 +178,7 @@ module "sms_msg_sender_label" {
 
 module "sms_msg_sender_code" {
   source  = "cruxstack/artifact-packager/docker"
-  version = "1.3.6"
+  version = "1.4.0"
   count   = local.sms_sender_enabled ? 1 : 0
 
   artifact_src_path    = "/tmp/package.zip"
@@ -332,7 +332,7 @@ module "email_msg_sender_label" {
 
 module "email_msg_sender_code" {
   source  = "cruxstack/artifact-packager/docker"
-  version = "1.3.6"
+  version = "1.4.0"
   count   = local.email_sender_enabled ? 1 : 0
 
   artifact_src_path    = "/tmp/package.zip"


### PR DESCRIPTION
## Summary

Combines all open Dependabot PRs into a single PR for easier review and merge.

### Dependency Updates

**GitHub Actions:**
- `actions/checkout` from 3 to 6
- `amannn/action-semantic-pull-request` from 5.2.0 to 6.1.1
- `mathieudutour/github-tag-action` from 6.1 to 6.2
- `ncipollo/release-action` from 1.12.0 to 1.20.0

**Terraform:**
- `cruxstack/artifact-packager/docker` from 1.3.6 to 1.4.0

### Related PRs

Closes #11, closes #12, closes #13, closes #14, closes #15