### PR TITLE
fix: handle null sendgrid verification api key when using offline pro…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Bump Version
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: minor
           custom_release_rules: bug:patch:Fixes,chore:patch:Chores,docs:patch:Documentation,feat:minor:Features,refactor:minor:Refactors,test:patch:Tests,ci:patch:Development,dev:patch:Development
       - name: Create Release
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.20.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+        uses: actions/checkout@v6
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         name: Check PR for Semantic Commit Message
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
       - name: Terraform Setup

--- a/main.tf
+++ b/main.tf
@@ -178,7 +178,7 @@ module "sms_msg_sender_label" {
 
 module "sms_msg_sender_code" {
   source  = "cruxstack/artifact-packager/docker"
-  version = "1.3.6"
+  version = "1.4.0"
   count   = local.sms_sender_enabled ? 1 : 0
 
   artifact_src_path    = "/tmp/package.zip"
@@ -332,7 +332,7 @@ module "email_msg_sender_label" {
 
 module "email_msg_sender_code" {
   source  = "cruxstack/artifact-packager/docker"
-  version = "1.3.6"
+  version = "1.4.0"
   count   = local.email_sender_enabled ? 1 : 0
 
   artifact_src_path    = "/tmp/package.zip"
@@ -380,13 +380,13 @@ resource "aws_lambda_function" "email_msg_sender" {
       APP_EMAIL_SENDER_POLICY_PATH            = local.email_sender_policy_path
       APP_EMAIL_VERIFICATION_ENABLED          = coalesce(var.sendgrid_email_verification_enabled, var.email_verification_enabled)
       APP_EMAIL_VERIFICATION_PROVIDER         = var.email_verification_provider
-      APP_EMAIL_VERIFICATION_WHITELIST        = join(",", coalescelist(var.sendgrid_email_verification_allowlist, var.email_verification_whitelist))
+      APP_EMAIL_VERIFICATION_WHITELIST        = join(",", concat(var.sendgrid_email_verification_allowlist, var.email_verification_whitelist))
       APP_EMAIL_FAILOVER_ENABLED              = var.email_failover_enabled
       APP_EMAIL_FAILOVER_PROVIDERS            = join(",", var.email_failover_providers)
       APP_EMAIL_FAILOVER_CACHE_TTL            = var.email_failover_cache_ttl
       APP_SENDGRID_API_HOST                   = var.sendgrid_api_host
       APP_SENDGRID_EMAIL_SEND_API_KEY         = var.sendgrid_email_send_api_key
-      APP_SENDGRID_EMAIL_VERIFICATION_API_KEY = coalesce(var.sendgrid_email_verification_api_key, var.sendgrid_api_key)
+      APP_SENDGRID_EMAIL_VERIFICATION_API_KEY = try(coalesce(var.sendgrid_email_verification_api_key, var.sendgrid_api_key), "")
     }
   }
 


### PR DESCRIPTION
…vider (#18)

* fix: handle empty whitelist in email verification config

* chore(deps): combine dependabot updates (#16)

- Bump actions/checkout from 3 to 6
- Bump amannn/action-semantic-pull-request from 5.2.0 to 6.1.1
- Bump mathieudutour/github-tag-action from 6.1 to 6.2
- Bump ncipollo/release-action from 1.12.0 to 1.20.0
- Bump cruxstack/artifact-packager/docker from 1.3.6 to 1.4.0

* fix: handle null sendgrid verification api key when using offline provider

Wrap coalesce() in try() with empty string fallback for APP_SENDGRID_EMAIL_VERIFICATION_API_KEY so that terraform plan does not fail when email_verification_provider is 'offline' and no SendGrid API key is provided.

Closes #17