### PR TITLE
fix: use correct ses: IAM action prefix for GetAccount

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,10 +108,10 @@ data "aws_iam_policy_document" "this" {
     content {
       effect = "Allow"
       actions = [
+        "ses:GetAccount",
         "ses:GetTemplate",
         "ses:SendEmail",
         "ses:SendTemplatedEmail",
-        "sesv2:GetAccount",
       ]
       resources = [
         "*"


### PR DESCRIPTION
## Summary

- Replaces invalid `sesv2:GetAccount` IAM action with `ses:GetAccount` in the email sender Lambda's IAM policy. The SES v2 API uses the `ses:` IAM namespace — there is no `sesv2:` prefix in IAM.
- Without this fix, failover health checks always fail with `AccessDeniedException`, causing SES to be skipped entirely.

Closes #20