### PR TITLE
fix!: use key_schema for deprecated GSI hash_key/range_key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -291,16 +291,28 @@ resource "aws_dynamodb_table" "sms_history" {
   }
 
   global_secondary_index {
-    name            = "userSid-index"
-    hash_key        = "userId"
-    range_key       = "sentAtEpoch"
+    name = "userSid-index"
+    key_schema {
+      attribute_name = "userId"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "sentAtEpoch"
+      key_type       = "RANGE"
+    }
     projection_type = "ALL"
   }
 
   global_secondary_index {
-    name            = "userPhoneNumber-index"
-    hash_key        = "userPhoneNumber"
-    range_key       = "sentAtEpoch"
+    name = "userPhoneNumber-index"
+    key_schema {
+      attribute_name = "userPhoneNumber"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "sentAtEpoch"
+      key_type       = "RANGE"
+    }
     projection_type = "ALL"
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.37.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
## Summary

The `global_secondary_index` `hash_key`/`range_key` arguments on `aws_dynamodb_table` are deprecated in the latest AWS provider ("range_key is deprecated. Use key_schema instead."). This converts both GSIs on the `sms_history` table (`userSid-index`, `userPhoneNumber-index`) to the `key_schema` block.

- Confirmed against the provider schema (v6.49.0): **GSI** `hash_key`/`range_key` are deprecated and a GSI `key_schema` block exists; **top-level** table `hash_key`/`range_key` are **not** deprecated and have no `key_schema` equivalent — so the table primary key is left unchanged.
- `terraform validate` passes.

## Provider floor
Raises the AWS provider requirement from `>= 5.0.0` to `>= 6.37.0`:
- GSI `key_schema` support was introduced in **v6.29.0**.
- The `hash_key`/`range_key` → `key_schema` migration no-op and GSI-recreation fixes landed by **v6.37.0** (#46442, #46512, #46602).

**BREAKING CHANGE:** minimum AWS provider is now `>= 6.37.0`; suggest a major version release.

## Migration note
On provider >= 6.37.0 the switch from `hash_key`/`range_key` to an identical `key_schema` is treated as a no-op. Existing consumers should still run a `plan` to confirm no GSI recreation before applying.